### PR TITLE
Remover comentário de dentro de bloco shell

### DIFF
--- a/aulas/01.md
+++ b/aulas/01.md
@@ -153,10 +153,10 @@ def read_root():
     return {'message': 'Olá Mundo!'}
 ```
 
-Agora, podemos iniciar nosso servidor FastAPI com o seguinte comando:
+Agora, podemos ativar o ambiente virtual e iniciar nosso servidor FastAPI com os seguintes comandos:
 
 ```shell title="$ Execução no terminal!"
-poetry shell  # Para ativar o ambiente virtual
+poetry shell
 uvicorn fast_zero.app:app --reload
 ```
 


### PR DESCRIPTION
Proponho tirar o comentário de dentro do comando shell, pois alguém pode rodar o comando com o comentário, não reparar que o `poetry shell` falhou e executar comandos foram do venv.