### PR TITLE
Imports não usados/faltando no código da documentação.

### DIFF
--- a/aulas/03.md
+++ b/aulas/03.md
@@ -164,7 +164,8 @@ Vamos criar uma fixture para a conexão com o banco de dados chamada `session`:
 
 ```python title="tests/conftest.py"
 # ...
-from sqlalchemy import create_engine, select
+import pytest
+from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from fast_zero.models import Base


### PR DESCRIPTION
Seguindo o fluxo [desta parte](https://github.com/HenriqueCCdA/fastapi-do-zero/blob/main/aulas/03.md#criando-uma-fixture-para-intera%C3%A7%C3%B5es-com-o-banco-de-dados) eu tive dois problemas na hora de rodar os testes, foram eles:

- Faltava importar o `pytest`
- o `select` foi importado mais não foi usado.