### PR TITLE
Correção de typo

### DIFF
--- a/aulas/02.md
+++ b/aulas/02.md
@@ -461,7 +461,7 @@ Por exemplo, para nossa mensagem simples retornada por `read_root` (`#!python {'
 }
 ```
 
-Onde estamos dizendo ao cliente que ao chamar a API, será retornado um objeto, esse objeto contem a propriedade `#!python "message"`, a mensagem será do tipo `string`. Ao final, vemos que o campo `message` é requerido. Isso quer dizer que ele sempre será enviado na resposta.
+Onde estamos dizendo ao cliente que ao chamar a API, será retornado um objeto, esse objeto contém a propriedade `#!python "message"`, a mensagem será do tipo `string`. Ao final, vemos que o campo `message` é requerido. Isso quer dizer que ele sempre será enviado na resposta.
 
 ??? example "E em casos mais complicados, como ficaria o schema?"
 	Para o exemplo que fizemos antes, sobre os livros, o schema seria assim:


### PR DESCRIPTION
De acordo com o [Dicio](https://www.dicio.com.br/contem-ou-contem/), nesse contexto, o correto é `contém`, com acento agudo.