### PR TITLE
Mudança do metodo no datetime

### DIFF
--- a/aulas/06.md
+++ b/aulas/06.md
@@ -127,7 +127,7 @@ pwd_context = CryptContext(schemes=['bcrypt'], deprecated='auto')
 
 def create_access_token(data: dict):
     to_encode = data.copy()
-    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    expire = datetime.now() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({'exp': expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/aulas/07.md
+++ b/aulas/07.md
@@ -562,7 +562,7 @@ Com isso, todos os lugares onde as constantes eram usadas devem ser substituído
 ```python title="fast_zero/security.py"
 def create_access_token(data: dict):
     to_encode = data.copy()
-    expire = datetime.utcnow() + timedelta(
+    expire = datetime.now() + timedelta(
         minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
     )
     to_encode.update({'exp': expire})


### PR DESCRIPTION
- **O metodo datetime.utcnow() foi descontinuado na versão 3.12, fiz a modificação para ultilizar o metodo datime.now(), para evitar receber notificação do lsp**
- Modifiquei apenas na aula 6
- https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
