### PR TITLE
Adiciona ruff check

### DIFF
--- a/aulas/01.md
+++ b/aulas/01.md
@@ -396,7 +396,7 @@ Alguns comandos que criaremos agora no início:
 
 ```toml title="pyproject.toml" linenums="37"
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'
@@ -459,7 +459,7 @@ Para executar um comando, é bem mais simples, precisando somente passar a palav
 	extend-exclude = '(migrations/)'
 
 	[tool.taskipy.tasks]
-	lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+	lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 	format = 'blue .  && isort .'
 	run = 'uvicorn fast_zero.app:app --reload'
 	pre_test = 'task lint'

--- a/codigo_das_aulas/01/pyproject.toml
+++ b/codigo_das_aulas/01/pyproject.toml
@@ -35,7 +35,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/02/pyproject.toml
+++ b/codigo_das_aulas/02/pyproject.toml
@@ -35,7 +35,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/03/pyproject.toml
+++ b/codigo_das_aulas/03/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 python = "^3.11"
 uvicorn = "^0.25.0"
 fastapi = "^0.109.0"
-pydantic = {extras = ["email"], version = "^2.6.0"}
+pydantic = { extras = ["email"], version = "^2.6.0" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.4"
@@ -36,7 +36,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/04/pyproject.toml
+++ b/codigo_das_aulas/04/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
@@ -40,7 +40,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/05/pyproject.toml
+++ b/codigo_das_aulas/05/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
@@ -40,7 +40,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/06/pyproject.toml
+++ b/codigo_das_aulas/06/pyproject.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
-passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 python-multipart = "^0.0.6"
 pyjwt = "^2.8.0"
 
@@ -43,7 +43,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/07/pyproject.toml
+++ b/codigo_das_aulas/07/pyproject.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
-passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 python-multipart = "^0.0.6"
 pyjwt = "^2.8.0"
 
@@ -43,7 +43,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/08/pyproject.toml
+++ b/codigo_das_aulas/08/pyproject.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
-passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 python-multipart = "^0.0.6"
 pyjwt = "^2.8.0"
 
@@ -45,7 +45,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/09/pyproject.toml
+++ b/codigo_das_aulas/09/pyproject.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
-passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 python-multipart = "^0.0.6"
 pyjwt = "^2.8.0"
 
@@ -45,7 +45,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/10/pyproject.toml
+++ b/codigo_das_aulas/10/pyproject.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
-passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 python-multipart = "^0.0.6"
 psycopg2-binary = "^2.9.9"
 pyjwt = "^2.8.0"
@@ -46,7 +46,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/11/pyproject.toml
+++ b/codigo_das_aulas/11/pyproject.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
-passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 python-multipart = "^0.0.6"
 psycopg2-binary = "^2.9.9"
 pyjwt = "^2.8.0"
@@ -46,7 +46,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'

--- a/codigo_das_aulas/12/pyproject.toml
+++ b/codigo_das_aulas/12/pyproject.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 description = ""
 authors = ["dunossauro <mendesxeduardo@gmail.com>"]
 readme = "README.md"
-packages = [{include = "fast_zero"}]
+packages = [{ include = "fast_zero" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100.0"
 uvicorn = "^0.22.0"
-pydantic = {extras = ["email"], version = "^2.0.2"}
+pydantic = { extras = ["email"], version = "^2.0.2" }
 sqlalchemy = "^2.0.18"
 pydantic-settings = "^2.0.1"
 alembic = "^1.11.1"
-passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 python-multipart = "^0.0.6"
 psycopg2-binary = "^2.9.9"
 pyjwt = "^2.8.0"
@@ -46,7 +46,7 @@ pythonpath = "."
 extend-exclude = '(migrations/)'
 
 [tool.taskipy.tasks]
-lint = 'ruff . && blue --check . --diff && isort --check . --diff'
+lint = 'ruff check . && blue --check . --diff && isort --check . --diff'
 format = 'blue .  && isort .'
 run = 'uvicorn fast_zero.app:app --reload'
 pre_test = 'task lint'


### PR DESCRIPTION
Para rodar o ruff futuramente será necessário  usar o argumento `ruff check <path>`, ou segundo esse [PR](https://github.com/astral-sh/ruff/pull/10217) na documentação da release v0.3.3 do ruff, apenas o `ruff check` bastaria para executar o linter.

![Screenshot from 2024-03-26 21-10-35](https://github.com/dunossauro/fastapi-do-zero/assets/80861021/621b4003-cae0-4f78-b117-5cc5a225b2e3)

Este PR atualiza a aula **01.md** e todos os arquivos **pyproject.toml** nos códigos das aulas.
