### PR TITLE
Retira v3.11 fixo no templates/poetry.md

### DIFF
--- a/aulas/templates/poetry.md
+++ b/aulas/templates/poetry.md
@@ -4,7 +4,7 @@
 	pyenv local {{full_version}}  # (1)!
 	```
 
-	1. Essa era a maior versão do 3.11 quando escrevi
+	1. Essa era a maior versão do {{short_version}} quando escrevi
 
 	Esse comando criará um arquivo oculto chamado `.python-version` na raiz do nosso projeto:
 


### PR DESCRIPTION
Este PR visa corrigir o hint de uma  janela carregada na aula 01, quando se seleciona a opção de python 3.12 ao invés de python 3.11. Segue print:
![Captura de tela 2024-05-01 135740](https://github.com/dunossauro/fastapi-do-zero/assets/80999926/ecc8ae0d-156a-456c-88e7-32b3b5c82f00)

