### PR TITLE
Aula 02 - Ajuste no import da classe Message

### DIFF
--- a/aulas/02.md
+++ b/aulas/02.md
@@ -553,7 +553,7 @@ from http import HTTPStatus
 
 from fastapi import FastAPI
 
-from fast_test.schemas import Message
+from fast_zero.schemas import Message
 
 app = FastAPI()
 


### PR DESCRIPTION
Na seção [Integrando o Pydantic com o FastAPI](https://fastapidozero.dunossauro.com/02/#integrando-o-pydantic-com-o-fastapi) está constando o import incorreto da classe Message implementada no bloco de código anterior.

Como está: `from fast_test.schemas import Message`
Como é esperado: `from fast_zero.schemas import Message`

Este PR visa corrigir esta situação