### PR TITLE
Aula 04 - ajusta legibilidade e corrige typo

### DIFF
--- a/aulas/04.md
+++ b/aulas/04.md
@@ -163,7 +163,7 @@ class User:
     )
 ```
 
-Uma menção especial ao campo `init`. Ele diz que quando a classe é instanciada, o SQLAlchemy irá atribuir um valor automaticamente para o atributo. No caso das chaves primárias, elas serão incrementadas automaticamente. O campo `created_ad` executa a função atrelada ao parâmetro `server_default`, no caso atribuindo `func.now()` ao campo.
+Uma menção especial ao parâmetro `init`. Com valor `False`, ele indica que quando a classe é instanciada o SQLAlchemy não deve atribuir um valor automaticamente para o campo respectivo. No caso das chaves primárias, elas serão incrementadas automaticamente. O campo `created_at` executa a função atrelada ao parâmetro `server_default`, no caso atribuindo `func.now()` ao campo.
 
 
 > Existem diversas opções nessa função. Caso queira ver mais possibilidades de mapeamento, aqui está a [referencia para mais campos](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.mapped_column){:target="_blank"}


### PR DESCRIPTION
Este parágrafo em específico da aula 04 tive dificuldade de compreendê-lo. Talvez pelo fato de o exemplo estar setado com init=False, e a explicação original estar vinculada a eventual valor True.
Reescrevi substituindo o termo "campo" por "parâmetro" e indicando o efeito que causa com valor False, da maneira que está no bloco de código.
Além disso tem a correção de typo `created_ad` para `created_at`