### PR TITLE
Fix typo confitest.py

### DIFF
--- a/aulas/06.md
+++ b/aulas/06.md
@@ -368,7 +368,7 @@ tests/test_app.py::test_get_token FAILED
 
 Para corrigir isso, precisamos garantir que a senha esteja sendo criptografada na fixture antes de ser salva:
 
-```python title="tests/confitest.py" hl_lines="1 10"
+```python title="tests/conftest.py" hl_lines="1 10"
 from fast_zero.security import get_password_hash
 
 # ...
@@ -398,7 +398,7 @@ tests/test_app.py::test_get_token FAILED
 
 Para resolver isso, faremos uma modificação no objeto user (um monkey patch) para adicionar a senha em texto puro:
 
-```python title="tests/confitest.py" linenums="1" hl_lines="13"
+```python title="tests/conftest.py" linenums="1" hl_lines="13"
 @pytest.fixture()
 def user(session):
     password = 'testtest'

--- a/slides/brutos/aula_06.md
+++ b/slides/brutos/aula_06.md
@@ -408,7 +408,7 @@ def user(session):
 Embora a senha agora consiga ser comparada, a senha que enviamos na requisição está indo suja também.
 
 ```python
-# confitest.py
+# conftest.py
 @pytest.fixture
 def user(session):
     password = 'testtest'

--- a/slides/html/aula_06.html
+++ b/slides/html/aula_06.html
@@ -370,7 +370,7 @@ SECRET_KEY = <span class="hljs-string">&#x27;your-secret-key&#x27;</span>  <span
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="28" data-theme="m1vu1ogkfxew7l9ve2tr9r09y0mpcci7vua2h766hdvoc" style="--theme:m1vu1ogkfxew7l9ve2tr9r09y0mpcci7vua2h766hdvoc;">
 <h1 id="problema-2">Problema 2!</h1>
 <p>Embora a senha agora consiga ser comparada, a senha que enviamos na requisição está indo suja também.</p>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-python"><span class="hljs-comment"># confitest.py</span>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-python"><span class="hljs-comment"># conftest.py</span>
 <span class="hljs-meta">@pytest.fixture</span>
 <span class="hljs-keyword">def</span> <span class="hljs-title function_">user</span>(<span class="hljs-params">session</span>):
     password = <span class="hljs-string">&#x27;testtest&#x27;</span>


### PR DESCRIPTION
Ajuste de typo da aula 06. Foi feito um replace all de `confitest.py` para `conftest.py`.

Reparei lendo o arquivo `aulas/06.md` mas vi que também ocorreu em alguns arquivos de slides da aula 06 - os quais não cheguei a visualizar, mas também entraram no replace all do typo.