### PR TITLE
Fix typo expected_todos

### DIFF
--- a/aulas/09.md
+++ b/aulas/09.md
@@ -491,7 +491,7 @@ Também queremos verificar se a filtragem por título está funcionando conforme
 def test_list_todos_filter_title_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, title='Test todo 1')
     )
@@ -502,7 +502,7 @@ def test_list_todos_filter_title_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 ```
 
 Este teste garante que quando o filtro de título é aplicado, apenas as tarefas com o título correspondente são retornadas.
@@ -515,7 +515,7 @@ Da mesma forma, queremos testar o filtro de descrição.
 def test_list_todos_filter_description_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, description='description')
     )
@@ -526,7 +526,7 @@ def test_list_todos_filter_description_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 ```
 
 Este teste verifica que, quando filtramos pela descrição, apenas as tarefas com a descrição correspondente são retornadas.
@@ -539,7 +539,7 @@ Finalmente, precisamos testar o filtro de estado.
 def test_list_todos_filter_state_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, state=TodoState.draft)
     )
@@ -550,7 +550,7 @@ def test_list_todos_filter_state_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 ```
 
 Este teste garante que quando filtramos pelo estado, apenas as tarefas com o estado correspondente são retornadas.
@@ -567,7 +567,7 @@ A seguir, apresento o código do teste:
 def test_list_todos_filter_combined_should_return_5_todos(
     session, user, client, token
 ):
-    exptect_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(
             5,
@@ -594,7 +594,7 @@ def test_list_todos_filter_combined_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == 5
+    assert len(response.json()['todos']) == expected_todos
 ```
 
 Com esses testes, cobrimos todas as possíveis variações de query strings para o nosso endpoint, garantindo que ele funciona corretamente em todas essas situações. A abordagem modular para escrever esses testes facilita a leitura e a manutenção, além de permitir uma cobertura de teste abrangente e robusta.

--- a/codigo_das_aulas/09/tests/test_todos.py
+++ b/codigo_das_aulas/09/tests/test_todos.py
@@ -53,7 +53,7 @@ def test_list_todos_pagination_should_return_2_todos(
 def test_list_todos_filter_title_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, title='Test todo 1')
     )
@@ -64,13 +64,13 @@ def test_list_todos_filter_title_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_description_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, description='description')
     )
@@ -81,13 +81,13 @@ def test_list_todos_filter_description_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_state_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, state=TodoState.draft)
     )
@@ -98,13 +98,13 @@ def test_list_todos_filter_state_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_combined_should_return_5_todos(
     session, user, client, token
 ):
-    exptect_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(
             5,
@@ -131,7 +131,7 @@ def test_list_todos_filter_combined_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptect_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_patch_todo_error(client, token):

--- a/codigo_das_aulas/10/tests/test_todos.py
+++ b/codigo_das_aulas/10/tests/test_todos.py
@@ -53,7 +53,7 @@ def test_list_todos_pagination_should_return_2_todos(
 def test_list_todos_filter_title_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, title='Test todo 1')
     )
@@ -64,13 +64,13 @@ def test_list_todos_filter_title_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_description_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, description='description')
     )
@@ -81,13 +81,13 @@ def test_list_todos_filter_description_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_state_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, state=TodoState.draft)
     )
@@ -98,13 +98,13 @@ def test_list_todos_filter_state_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_combined_should_return_5_todos(
     session, user, client, token
 ):
-    exptect_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(
             5,
@@ -131,7 +131,7 @@ def test_list_todos_filter_combined_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptect_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_patch_todo_error(client, token):

--- a/codigo_das_aulas/11/tests/test_todos.py
+++ b/codigo_das_aulas/11/tests/test_todos.py
@@ -53,7 +53,7 @@ def test_list_todos_pagination_should_return_2_todos(
 def test_list_todos_filter_title_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, title='Test todo 1')
     )
@@ -64,13 +64,13 @@ def test_list_todos_filter_title_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_description_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, description='description')
     )
@@ -81,13 +81,13 @@ def test_list_todos_filter_description_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_state_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, state=TodoState.draft)
     )
@@ -98,13 +98,13 @@ def test_list_todos_filter_state_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_combined_should_return_5_todos(
     session, user, client, token
 ):
-    exptect_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(
             5,
@@ -131,7 +131,7 @@ def test_list_todos_filter_combined_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptect_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_patch_todo_error(client, token):

--- a/codigo_das_aulas/12/tests/test_todos.py
+++ b/codigo_das_aulas/12/tests/test_todos.py
@@ -53,7 +53,7 @@ def test_list_todos_pagination_should_return_2_todos(
 def test_list_todos_filter_title_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, title='Test todo 1')
     )
@@ -64,13 +64,13 @@ def test_list_todos_filter_title_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_description_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, description='description')
     )
@@ -81,13 +81,13 @@ def test_list_todos_filter_description_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_state_should_return_5_todos(
     session, user, client, token
 ):
-    exptected_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(5, user_id=user.id, state=TodoState.draft)
     )
@@ -98,13 +98,13 @@ def test_list_todos_filter_state_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptected_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_list_todos_filter_combined_should_return_5_todos(
     session, user, client, token
 ):
-    exptect_todos = 5
+    expected_todos = 5
     session.bulk_save_objects(
         TodoFactory.create_batch(
             5,
@@ -131,7 +131,7 @@ def test_list_todos_filter_combined_should_return_5_todos(
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert len(response.json()['todos']) == exptect_todos
+    assert len(response.json()['todos']) == expected_todos
 
 
 def test_patch_todo_error(client, token):


### PR DESCRIPTION
Título do PR é autoexplicativo. Foi feito um replace all nos typos relacionados a expected_todos que identifiquei lendo a aula 09.

Além do typo fiz um pequeno ajuste num assert de `aulas/09.md` para que constasse a variável expected_todos ao invés do literal 5.

```diff
-    assert len(response.json()['todos']) == 5
+    assert len(response.json()['todos']) == expected_todos
```