### PR TITLE
Aula10 ajustes menores

### DIFF
--- a/aulas/10.md
+++ b/aulas/10.md
@@ -41,33 +41,14 @@ Uma das coisas interessantes sobre Docker é que existe um [Hub de containers](h
 
 Aqui está um exemplo de `Dockerfile` para executar nossa aplicação:
 
-```docker
-FROM python:3.11-slim
-ENV POETRY_VIRTUALENVS_CREATE=false
-
-WORKDIR app/
-COPY . .
-
-RUN pip install poetry
-
-RUN poetry config installer.max-workers 10
-RUN poetry install --no-interaction --no-ansi
-
-EXPOSE 8000
-CMD poetry run uvicorn --host 0.0.0.0 fast_zero.app:app
-```
-
-Aqui está o que cada linha faz:
-
-1. `FROM python:3.11-slim`: define a imagem base para nosso contêiner. Estamos usando a versão slim da imagem do Python 3.11, que tem tudo que precisamos para rodar nossa aplicação.
-2. `ENV POETRY_VIRTUALENVS_CREATE=false`: define uma variável de ambiente que diz ao Poetry para não criar um ambiente virtual. (O container já é um ambiente isolado)
-3. `RUN pip install poetry`: instala o Poetry, nosso gerenciador de pacotes.
-4. `WORKDIR app/`: define o diretório em que executaremos os comandos a seguir.
-5. `COPY . .`: copia todos os arquivos do diretório atual para o contêiner.
-6. `RUN poetry config installer.max-workers 10`: configura o Poetry para usar até 10 workers ao instalar pacotes.
-7. `RUN poetry install --no-interaction --no-ansi`: instala as dependências do nosso projeto sem interação e sem cores no output.
-8. `EXPOSE 8000`: informa ao Docker que o contêiner escutará na porta 8000.
-9. `CMD poetry run uvicorn --host 0.0.0.0 fast_zero.app:app`: define o comando que será executado quando o contêiner for iniciado.
+=== "Versão 3.11"
+{%set full_version = "3.11.9" %}
+{%set short_version = 3.11 %}
+{% include "templates/dockerfile.md" %}
+=== "Versão 3.12"
+{%set full_version = "3.12.3" %}
+{%set short_version = 3.12 %}
+{% include "templates/dockerfile.md" %}
 
 Vamos entender melhor esse último comando:
 
@@ -99,7 +80,7 @@ Este comando lista todas as imagens Docker disponíveis no seu sistema.
 Para executar o contêiner, usamos o comando `docker run`. Especificamos o nome do contêiner com a flag `--name`, indicamos a imagem que queremos executar e a tag que queremos usar `<nome_da_imagem>:<tag>`. A flag `-p` serve para mapear a porta do host para a porta do contêiner `<porta_do_host>:<porta_do_contêiner>`. Portanto, teremos o seguinte comando:
 
 ```shell title="$ Execução no terminal!"
-docker run --name fastzeroapp -p 8000:8000 fast_zero:latest
+docker run -it --name fastzeroapp -p 8000:8000 fast_zero:latest
 ```
 
 Este comando iniciará nossa aplicação dentro de um contêiner Docker, que estará escutando na porta 8000. Para testar se tudo está funcionando corretamente, você pode acessar `http://localhost:8000` em um navegador ou usar um comando como:
@@ -506,7 +487,7 @@ Vamos entender melhor o que cada parte do comando faz:
 
 Ao utilizar esse comando, o Docker Compose cuidará de iniciar os serviços dos quais `fastzero_app` depende, neste caso, o serviço `fastzero_database` do PostgreSQL. Isso é importante porque nossos testes podem depender de um banco de dados ativo para funcionar corretamente. O Compose garante que a ordem de inicialização dos serviços seja respeitada e que o serviço do banco de dados esteja pronto antes de iniciar os testes.
 
-Se executarmos o comando, vemos que ele inicia o banco de dados, inicia o container da aplicação e na sequência executa o comando que passamos no `--entreypoint` que é exatamente como executar os testes:
+Se executarmos o comando, vemos que ele inicia o banco de dados, inicia o container da aplicação e na sequência executa o comando que passamos no `--entrypoint` que é exatamente como executar os testes:
 
 ```shell title="$ Execução no terminal!"
 docker-compose run --entrypoint="poetry run task test" fastzero_app

--- a/aulas/10.md
+++ b/aulas/10.md
@@ -294,42 +294,40 @@ volumes:
 
 **Explicação linha a linha:**
 
-1. `version: '3'`: especifica a versão do formato do arquivo Compose. O número '3' é uma das versões mais recentes e amplamente usadas.
+1. `services:`: define os serviços (contêineres) que serão gerenciados.
 
-2. `services:`: define os serviços (contêineres) que serão gerenciados.
+2. `fastzero_database:`: define nosso serviço de banco de dados PostgreSQL.
 
-3. `fastzero_database:`: define nosso serviço de banco de dados PostgreSQL.
+3. `image: postgres`: usa a imagem oficial do PostgreSQL.
 
-4. `image: postgres`: usa a imagem oficial do PostgreSQL.
-
-5. `volumes:`: mapeia volumes para persistência de dados.
+4. `volumes:`: mapeia volumes para persistência de dados.
 
    - `pgdata:/var/lib/postgresql/data`: cria ou usa um volume chamado "pgdata" e o mapeia para o diretório `/var/lib/postgresql/data` no contêiner.
 
-6. `environment:`: define variáveis de ambiente para o serviço.
+5. `environment:`: define variáveis de ambiente para o serviço.
 
-7. `fastzero_app:`: define o serviço para nossa aplicação.
+6. `fastzero_app:`: define o serviço para nossa aplicação.
 
-8. `image: fastzero_app`: usa a imagem Docker da nossa aplicação.
+7. `image: fastzero_app`: usa a imagem Docker da nossa aplicação.
 
-9. `build:` : instruções para construir a imagem se não estiver disponível, nosso `Dockerfile`.
+8. `build:` : instruções para construir a imagem se não estiver disponível, nosso `Dockerfile`.
 
-10. `ports:`: mapeia portas do contêiner para o host.
+9. `ports:`: mapeia portas do contêiner para o host.
 
    - `"8000:8000"`: mapeia a porta 8000 do contêiner para a porta 8000 do host.
 
-11. `depends_on:`: especifica que `fastzero_app` depende de `fastzero_database`. Isto garante que o banco de dados seja iniciado antes da aplicação.
+10. `depends_on:`: especifica que `fastzero_app` depende de `fastzero_database`. Isto garante que o banco de dados seja iniciado antes da aplicação.
 
-12. `DATABASE_URL: ...`: é uma variável de ambiente que nossa aplicação usará para se conectar ao banco de dados. Aqui, ele se conecta ao serviço `fastzero_database` que definimos anteriormente.
+11. `DATABASE_URL: ...`: é uma variável de ambiente que nossa aplicação usará para se conectar ao banco de dados. Aqui, ele se conecta ao serviço `fastzero_database` que definimos anteriormente.
 
-13. `volumes:` (nível superior): define volumes que podem ser usados pelos serviços.
+12. `volumes:` (nível superior): define volumes que podem ser usados pelos serviços.
 
-14. `pgdata:`: define um volume chamado "pgdata". Este volume é usado para persistir os dados do PostgreSQL entre as execuções do contêiner.
+13. `pgdata:`: define um volume chamado "pgdata". Este volume é usado para persistir os dados do PostgreSQL entre as execuções do contêiner.
 
 !!! warning "Sobre o docker-compose"
 	Para usar o Docker Compose, você precisa tê-lo instalado em seu sistema. Ele não está incluído na instalação padrão do Docker, então lembre-se de instalá-lo separadamente!
 
-	O guia oficial de instalação pode ser encontrado [aqui](https://docs.docker.com/compose/install/){:target="_blank"}
+	O guia oficial de instalação pode ser encontrado [aqui](https://docs.docker.com/compose/install/standalone/){:target="_blank"}
 
 Com este arquivo `docker-compose.yml`, você pode iniciar ambos os serviços (aplicação e banco de dados) simultaneamente usando:
 

--- a/aulas/templates/dockerfile.md
+++ b/aulas/templates/dockerfile.md
@@ -1,0 +1,27 @@
+```docker
+FROM python:{{short_version}}-slim
+ENV POETRY_VIRTUALENVS_CREATE=false
+
+WORKDIR app/
+COPY . .
+
+RUN pip install poetry
+
+RUN poetry config installer.max-workers 10
+RUN poetry install --no-interaction --no-ansi
+
+EXPOSE 8000
+CMD poetry run uvicorn --host 0.0.0.0 fast_zero.app:app
+```
+
+Aqui está o que cada linha faz:
+
+1. `FROM python:{{short_version}}-slim`: define a imagem base para nosso contêiner. Estamos usando a versão slim da imagem do Python {{short_version}}, que tem tudo que precisamos para rodar nossa aplicação.
+2. `ENV POETRY_VIRTUALENVS_CREATE=false`: define uma variável de ambiente que diz ao Poetry para não criar um ambiente virtual. (O container já é um ambiente isolado)
+3. `RUN pip install poetry`: instala o Poetry, nosso gerenciador de pacotes.
+4. `WORKDIR app/`: define o diretório em que executaremos os comandos a seguir.
+5. `COPY . .`: copia todos os arquivos do diretório atual para o contêiner.
+6. `RUN poetry config installer.max-workers 10`: configura o Poetry para usar até 10 workers ao instalar pacotes.
+7. `RUN poetry install --no-interaction --no-ansi`: instala as dependências do nosso projeto sem interação e sem cores no output.
+8. `EXPOSE 8000`: informa ao Docker que o contêiner escutará na porta 8000.
+9. `CMD poetry run uvicorn --host 0.0.0.0 fast_zero.app:app`: define o comando que será executado quando o contêiner for iniciado.


### PR DESCRIPTION
Este PR contém os seguintes ajustes na aula 10:
- Deixa dockerfile compatível com python 3.11 ou 3.12. Vi na aula 01 o lance de usar janela com abas para cada versão, achei muito legal e usei o mesmo conceito para esse ajuste.
- Adiciona `-it` na primeira execução de docker para não travar o terminar e funcionar o Ctrl + C para sair do container
- Remove `version: '3'` da explicação do docker-compose
- Altera link de install do docker compose  para instalação do docker compose standalone (binário docker-compose). Achei importante essa alteração pq o link geral direciona para opções de instalar docker-compose de duas maneiras:
  - Como plugin do docker: dessa maneira os comandos são `docker compose`
  - Como standalone: dessa maneira os comandos são `docker-compose` - alinhados com os comandos executados no curso
- corrige typo entreypoint

Closes #159