### PR TITLE
Removendo os teste não escritos ainda

### DIFF
--- a/aulas/09.md
+++ b/aulas/09.md
@@ -605,10 +605,6 @@ tests/test_todos.py::test_list_todos_filter_title PASSED
 tests/test_todos.py::test_list_todos_filter_description PASSED
 tests/test_todos.py::test_list_todos_filter_state PASSED
 tests/test_todos.py::test_list_todos_filter_combined PASSED
-tests/test_todos.py::test_delete_todo PASSED
-tests/test_todos.py::test_delete_todo_error PASSED
-tests/test_todos.py::test_patch_todo_error PASSED
-tests/test_todos.py::test_patch_todo PASSED
 ```
 
 ## Endpoint de Alteração


### PR DESCRIPTION
Removi os testes que ainda não foram escritos e não deveriam estar aparecendo no output do test.