### PR TITLE
fix: Atualização doc aula 01 - frações do pyproject.toml

### DIFF
--- a/aulas/01.md
+++ b/aulas/01.md
@@ -397,7 +397,7 @@ Durante a análise estática do código, queremos buscar por coisas específicas
 - `PT` ([flake8-pytest](https://pypi.org/project/flake8-pytest-style/){:target="_blank"}): Checagem de boas práticas do Pytest
 
 ```toml title="pyproject.toml" linenums="24"
---8<-- "aulas/codigos/01/pyproject.toml:24:27"
+--8<-- "aulas/codigos/01/pyproject.toml:23:26"
 ```
 
 > Para mais informações sobre a configuração e sobre os códigos do ruff e dos projetos do PyCQA, você pode checar a [documentação do ruff](https://docs.astral.sh/ruff/rules){:target="_blank"} ou as documentações originais dos projetos [PyQCA](https://github.com/PyCQA){:target="_blank"}.
@@ -407,7 +407,7 @@ Durante a análise estática do código, queremos buscar por coisas específicas
 A formatação do Ruff praticamente não precisa ser alterada. Pois ele vai seguir as boas práticas e usar a configuração global de `79` caracteres por linha. A única alteração que farei é o uso de aspas simples `'` no lugar de aspas duplas `"`:
 
 ```toml title="pyproject.toml" linenums="28"
---8<-- "aulas/codigos/01/pyproject.toml:28:31"
+--8<-- "aulas/codigos/01/pyproject.toml:27:30"
 ```
 
 > Lembrando que a opção de usar aspas simples é totalmente pessoal, você pode usar aspas duplas se quiser.
@@ -417,7 +417,7 @@ A formatação do Ruff praticamente não precisa ser alterada. Pois ele vai segu
 O [Pytest](https://docs.pytest.org/){:target="_blank"} é uma framework de testes, que usaremos para escrever e executar nossos testes. O configuraremos para reconhecer o caminho base para execução dos testes na raiz do projeto `.`:
 
 ```toml title="pyproject.toml" linenums="32"
---8<-- "aulas/codigos/01/pyproject.toml:32:34"
+--8<-- "aulas/codigos/01/pyproject.toml:31:34"
 ```
 
 Na segunda linha dizemos para o pytest adicionar a opção `no:warnings`. Para ter uma visualização mais limpa dos testes, caso alguma biblioteca exiba uma mensagem de warning, isso será suprimido pelo pytest.
@@ -431,7 +431,7 @@ Isso funcionaria para qualquer comando complicado em nossa aplicação. Simplifi
 Alguns comandos que criaremos agora no início:
 
 ```toml title="pyproject.toml" linenums="36"
---8<-- "aulas/codigos/01/pyproject.toml:36:43"
+--8<-- "aulas/codigos/01/pyproject.toml:35:42"
 ```
 
 Os comandos definidos fazem o seguinte:


### PR DESCRIPTION
Pequeno ajuste nas frações de código do pyproject.toml descritas na aula de configuração do ambiente. Notei que algumas porções de código não estão mostrando a tag do que estamos configurando no projeto. Doczinha muito fera, agradeço demais!

![image](https://github.com/user-attachments/assets/3c9de9f3-bd5b-4835-bd2e-19698b8e2abe)

![image](https://github.com/user-attachments/assets/d14615cd-c9e3-4b60-b596-f2bd9d4c3e68)

![image](https://github.com/user-attachments/assets/eeaed610-8970-40f2-a640-f6c1a2258b11)

![image](https://github.com/user-attachments/assets/d85002d3-fa24-49ad-965b-f3f81d1c93ea)
