### PR TITLE
Corrige a seqüência de comentários nos códigos

### DIFF
--- a/aulas/04.md
+++ b/aulas/04.md
@@ -257,10 +257,10 @@ def session():
     engine = create_engine('sqlite:///:memory:')#(1)!
     table_registry.metadata.create_all(engine)#(2)!
 
-    with Session(engine) as session:
+    with Session(engine) as session:#(3)!
         yield session#(4)!
 
-    table_registry.metadata.drop_all(engine)#(3)!
+    table_registry.metadata.drop_all(engine)#(5)!
 ```
 
 Aqui, estamos utilizando o SQLite como o banco de dados em memória para os testes. Essa é uma prática comum em testes unitários, pois a utilização de um banco de dados em memória é mais rápida do que um banco de dados persistido em disco. Com o SQLite em memória, podemos criar e destruir bancos de dados facilmente, o que é útil para isolar os testes e garantir que os dados de um teste não afetem outros testes. Além disso, não precisamos nos preocupar com a limpeza dos dados após a execução dos testes, já que o banco de dados em memória é descartado quando o programa é encerrado.
@@ -269,9 +269,9 @@ O que cada linha da fixture faz?
 
 1. `create_engine('sqlite:///:memory:')`: cria um mecanismo de banco de dados SQLite em memória usando SQLAlchemy. Este mecanismo será usado para criar uma sessão de banco de dados para nossos testes.
 
-2. `Session(engine)`: cria uma sessão `Session` para que os testes possam se comunicar com o banco de dados. Por conta do `yield` a sessão é sempre renovada após cada teste.
+2. `table_registry.metadata.create_all(engine)`: cria todas as tabelas no banco de dados de teste antes de cada teste que usa a fixture `session`.
 
-3. `table_registry.metadata.create_all(engine)`: cria todas as tabelas no banco de dados de teste antes de cada teste que usa a fixture `session`.
+3. `Session(engine)`: cria uma sessão `Session` para que os testes possam se comunicar com o banco de dados. Por conta do `yield` a sessão é sempre renovada após cada teste.
 
 4. `yield Session()`: fornece uma instância de Session que será injetada em cada teste que solicita a fixture `session`. Essa sessão será usada para interagir com o banco de dados de teste.
 


### PR DESCRIPTION
Os comentários dos códigos estão incorretos. Reorganizando as referências.