### PR TITLE
fix: Texto sobre assincronismo na função `get_current_user`

### DIFF
--- a/aulas/06.md
+++ b/aulas/06.md
@@ -545,7 +545,7 @@ def get_current_user(
 4. Nessa validação é testada se o token é um token JWT válido. Caso não seja, o erro também será levantado.
 5. Nossa última validação checa, após de garantir que existe `username`, se ele está presente em nossa base de dados. Caso não, o erro será levantado. 
 
-Aqui, a função `get_current_user` é definida como assíncrona, indicando que ela pode realizar operações de IO (como consultar um banco de dados) de forma não bloqueante. Esta função aceita dois argumentos: `session` e `token`. O `session` é obtido através da função `get_session` (não mostrada aqui), que deve retornar uma sessão de banco de dados ativa. O `token` é obtido do header de autorização da requisição, que é esperado ser do tipo Bearer (indicado pelo esquema OAuth2).
+Aqui, a função `get_current_user` aceita dois argumentos: `session` e `token`. O `session` é obtido através da função `get_session` (não mostrada aqui), que deve retornar uma sessão de banco de dados ativa. O `token` é obtido do header de autorização da requisição, que é esperado ser do tipo Bearer (indicado pelo esquema OAuth2).
 
 A variável `credentials_exception` é definida como uma exceção HTTP que será lançada sempre que houver um problema com as credenciais fornecidas pelo usuário. O status 401 indica que a autenticação falhou e a mensagem "Could not validate credentials" é retornada ao cliente. Além disso, um cabeçalho 'WWW-Authenticate' é incluído na resposta, indicando que o cliente deve fornecer autenticação.
 


### PR DESCRIPTION
A função `get_current_user` estava definida como síncrona. O ajuste retira o trecho sobre async e deixa o texto mais simples:

closes #240