### PR TITLE
Correção de typos no arquivo 07.md

### DIFF
--- a/aulas/07.md
+++ b/aulas/07.md
@@ -520,7 +520,7 @@ def read_users(session: Session, skip: int = 0, limit: int = 100):
 
 Embora isso não seja efetivamente um problema, parâmetros de `offset` e `limit` são bastante genéricos e podem ser usados em qualquer endpoint que precisar de paginação.
 
-Uma boa pratica de organização é seria um modelo do pydantic especializado em filtros, como:
+Uma boa prática de organização seria um modelo do pydantic especializado em filtros, como:
 
 
 ```python title="fast_zero/schemas.py"


### PR DESCRIPTION
"Seria" ou "é" podem ser usados, fica a seu critério.