### PR TITLE
Adicionando typos para procurar por erros de grafia no código das aulas

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,0 @@
-[default]
-extend-ignore-identifiers-re = ["selectin"]

--- a/aulas/01.md
+++ b/aulas/01.md
@@ -425,11 +425,12 @@ As ferramentas escolhidas são:
 - [ruff](https://docs.astral.sh/ruff/){:target="_blank"}: Uma ferramenta que tem duas funções no nosso código:
     1. Um analisador estático de código (um [linter](https://pt.wikipedia.org/wiki/Linter_(computa%C3%A7%C3%A3o)){:target="_blank"}), para dizer se não estamos infringindo alguma [boa prática de programação](https://docs.astral.sh/ruff/rules/){:target="_blank"};
 	2. Um formatador de código. Para seguirmos um estilo único de código. Vamos nos basear na [PEP-8](https://peps.python.org/pep-0008/){:target="_blank"}.
+- [typos](https://github.com/crate-ci/typos){:target="_blank"}: ferramenta para pegar erros de grafia em inglês no código. Como um não nativo de inglês, as vezes acabo escrevendo alguns nomes incorretos. Talvez isso ajude você também.
 
 Para instalar essas ferramentas que usaremos em desenvolvimento, podemos usar um grupo de dependências (`--group dev` no poetry) focado nelas, para não serem instaladas quando nossa aplicação estiver em produção:
 
 ```shell title="$ Execução no terminal!"
-poetry add --group dev pytest pytest-cov taskipy ruff
+poetry add --group dev pytest pytest-cov taskipy ruff typos
 ```
 
 ## Configurando as ferramentas de desenvolvimento
@@ -453,8 +454,8 @@ Para configurar o ruff montamos a configuração em 3 [tabelas](https://toml.io/
 
 Na configuração global do Ruff queremos alterar somente duas coisas. O comprimento de linha para 79 caracteres (conforme sugerido na [PEP-8](https://peps.python.org/pep-0008/){:target="_blank"}) e, em seguida, informaremos que o diretório de migrações de banco de dados será ignorado na checagem e na formatação:
 
-```toml title="pyproject.toml" linenums="21"
---8<-- "aulas/codigos/01/pyproject.toml:21:23"
+```toml title="pyproject.toml" linenums="22"
+--8<-- "aulas/codigos/01/pyproject.toml:22:25"
 ```
 
 ???+ example "Nota sobre "migrations""
@@ -471,8 +472,8 @@ Durante a análise estática do código, queremos buscar por coisas específicas
 - `PL` ([Pylint](https://pylint.pycqa.org/en/latest/index.html){:target="_blank"}): Como o `F`, também procura por erros em relação a boas práticas de código
 - `PT` ([flake8-pytest](https://pypi.org/project/flake8-pytest-style/){:target="_blank"}): Checagem de boas práticas do Pytest
 
-```toml title="pyproject.toml" linenums="25"
---8<-- "aulas/codigos/01/pyproject.toml:25:27"
+```toml title="pyproject.toml" linenums="27"
+--8<-- "aulas/codigos/01/pyproject.toml:27:29"
 ```
 
 > Para mais informações sobre a configuração e sobre os códigos do ruff e dos projetos do PyCQA, você pode checar a [documentação do ruff](https://docs.astral.sh/ruff/rules){:target="_blank"} ou as documentações originais dos projetos [PyQCA](https://github.com/PyCQA){:target="_blank"}.
@@ -481,8 +482,8 @@ Durante a análise estática do código, queremos buscar por coisas específicas
 
 A formatação do Ruff praticamente não precisa ser alterada. Pois ele vai seguir as boas práticas e usar a configuração global de `79` caracteres por linha. A única alteração que farei é o uso de aspas simples `'` no lugar de aspas duplas `"`:
 
-```toml title="pyproject.toml" linenums="29"
---8<-- "aulas/codigos/01/pyproject.toml:29:31"
+```toml title="pyproject.toml" linenums="31"
+--8<-- "aulas/codigos/01/pyproject.toml:31:33"
 ```
 
 > Lembrando que a opção de usar aspas simples é totalmente pessoal, você pode usar aspas duplas se quiser.
@@ -491,11 +492,49 @@ A formatação do Ruff praticamente não precisa ser alterada. Pois ele vai segu
 
 O [Pytest](https://docs.pytest.org/){:target="_blank"} é uma framework de testes, que usaremos para escrever e executar nossos testes. O configuraremos para reconhecer o caminho base para execução dos testes na raiz do projeto `.`:
 
-```toml title="pyproject.toml" linenums="33"
---8<-- "aulas/codigos/01/pyproject.toml:33:35"
+```toml title="pyproject.toml" linenums="35"
+--8<-- "aulas/codigos/01/pyproject.toml:35:37"
 ```
 
 Na segunda linha, dizemos para o pytest adicionar a opção `no:warnings`. Para ter uma visualização mais limpa dos testes, caso alguma biblioteca exiba uma mensagem de warning, isso será suprimido pelo pytest.
+
+### Typos
+
+O [typos](https://github.com/crate-ci/typos){:target="_blank"} vai nos ajudar com alguns errinhos que acabam acontecendo enquanto escrevemos código em inglês.
+
+Vamos supor que nosso código esteja assim:
+
+```python title="fast_zero/app.py" linenums="1" hl_lines="7"
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/')
+def read_root():
+	return {'{++messsage++}': 'Olá Mundo!'} #(1)!
+```
+
+1. Linha com um erro de grafia na escrita da string `#!py 'messsage'`. Escrita com um S a mais.
+
+Linha com um erro de grafia na escrita da string `#!py 'messsage'`. A palavra deveria ser escrita com dois "me-ss-age", não com três "me-sss-age".
+
+Esse tipo de erros bobos que o Typos nos ajuda a pegar. Se executarmos ele, `typos`, no terminal:
+
+```shell title="$ Execução no terminal!"
+typos
+```
+
+Nos apresentará uma resposta como essa:
+
+```shell title="$ Execução no terminal!"
+error: `messsage` should be `message`
+  ╭▸ ./fast_zero/app.py:7:14
+  │
+7 │     return {'messsage': 'Olá Mundo!'}
+  ╰╴             ━━━━━━━━
+```
+
+Nos dizendo que a string contida na linha `#!py 8` coluna `#!py 14` tem um erro: `messsage` deveria ser `message`.
 
 ### Taskipy
 
@@ -505,15 +544,16 @@ Isso funcionaria para qualquer comando complicado em nossa aplicação. Simplifi
 
 Alguns comandos que criaremos agora no início:
 
-```toml title="pyproject.toml" linenums="37"
---8<-- "aulas/codigos/01/pyproject.toml:37:44"
+```toml title="pyproject.toml" linenums="39"
+--8<-- "aulas/codigos/01/pyproject.toml:39:47"
 ```
 
 Os comandos definidos fazem o seguinte:
 
-- `lint`: Faz a checagem de boas práticas do código python
-- `pre_format`: Faz algumas correções de boas práticas automaticamente
-- `format`: Executa a formatação do código em relação às convenções de estilo de código
+- `pre_lint`: faz a busca por *typos* de inglês
+- `lint`: faz a checagem de boas práticas do código python
+- `pre_format`: faz algumas correções de boas práticas automaticamente
+- `format`: executa a formatação do código em relação às convenções de estilo de código
 - `run`: executa o servidor de desenvolvimento do FastAPI
 - `pre_test`: executa a camada de lint antes de executar os testes
 - `test`: executa os testes com pytest de forma verbosa (-vv) e adiciona nosso código como base de cobertura

--- a/aulas/10.md
+++ b/aulas/10.md
@@ -66,7 +66,7 @@ Neste código, chamamos o método `include_router` do FastAPI para cada roteador
 
 Agora, implementaremos a tabela 'Todos' no nosso banco de dados. Esta tabela estará diretamente relacionada à tabela 'User', pois toda tarefa pertence a um usuário. Esta relação é crucial para garantir que só o usuário dono da tarefa possa acessar e modificar suas tarefas.
 
-```python title="fast_zero/models.py" linenums="1" hl_lines="30-34 44 46"
+```python title="fast_zero/models.py" linenums="1" hl_lines="32-36 44 46"
 from datetime import datetime
 from enum import Enum
 
@@ -101,7 +101,7 @@ class User:
     todos: Mapped[list['Todo']] = relationship( #(2)!
         init=False,
 		cascade='all, delete-orphan',
-		lazy='selectin',
+		lazy='selectin', #(3)!
     )
 
 
@@ -112,9 +112,9 @@ class Todo:
     id: Mapped[int] = mapped_column(init=False, primary_key=True)
     title: Mapped[str]
     description: Mapped[str]
-    state: Mapped[TodoState] #(3)!
+    state: Mapped[TodoState] #(4)!
 
-    user_id: Mapped[int] = mapped_column(ForeignKey('users.id')) #(4)!
+    user_id: Mapped[int] = mapped_column(ForeignKey('users.id')) #(5)!
 ```
 
 1. Enums de strings no podem validar se o texto está entre as alternativas válidas. Algo como:
@@ -132,8 +132,9 @@ class Todo:
     ```
 
 2. Aqui criamos uma relação com a tabela `Todos`. Onde temos uma relação 1:N. Cada `User` pode ter `N` `Todo`s associados a ele. No `cascade` dizemos `#!python 'all, delete-orphan'` para que quando um `User` for deletado, todos os todos associados a ele também serão deletados. No campo `lazy` estamos usando `#!python 'selectin'`. O que quer dizer que quando fizermos um `select` em `Users` também vamos obter os objetos `Todo` associados a ele.
-3. `TodoState` cria uma relação entre o `Enum` e o campo `state`. Isso quer dizer que somente os valores no enum serão considerados válidos para esse campo.
-4. Aqui temos um relacionamento via chave estrangeira. Onde todo `Todo` é associado a um `id` de `User`.
+3. Lembre da string `#!py 'selectin'`, ela vai dar um problema em breve.
+4. `TodoState` cria uma relação entre o `Enum` e o campo `state`. Isso quer dizer que somente os valores no enum serão considerados válidos para esse campo.
+5. Aqui temos um relacionamento via chave estrangeira. Onde todo `Todo` é associado a um `id` de `User`.
 
 Neste ponto, é importante compreender o conceito de `relationship` no SQLAlchemy. A função `relationship` define como as duas tabelas irão interagir. Por exemplo, a tabela `User`, em seu campo `todo` pode exibir todos os objetos `Todo` associados a ela. Por exemplo, quando buscarmos por um `User` por meio de um `select` obteremos todos N objetos `Todo` associados ao seu `id`:
 
@@ -150,7 +151,30 @@ Nesse caso temos uma relação de 1 `User`, para N `Todo`.
 
 O argumento `cascade` determina o que ocorre com as tarefas quando o usuário associado a elas é deletado. Ao definir `#!python 'all, delete-orphan'`, estamos instruindo o SQLAlchemy a deletar todas as tarefas de um usuário quando este for deletado.
 
-Se formos executar nosso teste do db, ele deve falhar. Pois, temos um novo campo `todo` sendo retornado:
+Se formos executar nosso `test_db`, ele falhará por dois motivos bastante diferentes:
+
+1. Ao introduzir a string `#!py 'selectin'` temos um falso positivo de grafia:
+
+    Uma situação em que se parece bastante erro bastante simples de grafia, pois parece que esquecemos um `g` no final. Como em "selecting":
+    ```shell title="$ Execução no terminal!"
+	task test
+	error: `selectin` should be `selection`, `selecting`
+       ╭▸ ./fast_zero/models.py:39:15
+       │
+    39 │         lazy='selectin',
+       ╰╴              ━━━━━━━━
+    ```
+
+    Resolver essa situação é bastante simples. Criaremos na raiz do projeto um arquivo chamado `_typos.toml` e dizer que ele deve ignorar ocorrências da string `#!py 'selectin'`:
+
+    ```toml title="_typos.toml" linenums="1" hl_lines="2"
+    [default]
+    extend-ignore-identifiers-re = ["selectin"]
+    ```
+
+    Agora tudo deve estar certo para executar os testes novamente e passando com sucesso pela etapa de `pre_lint` do taskipy.
+
+2. O segundo é um erro no próprio teste. Pois, temos um novo campo, `todos`, sendo retornado:
 
 ```shell title="$ Execução no terminal!" hl_lines="11"
 task test -k db

--- a/aulas/apendices/c_versoes_usadas.md
+++ b/aulas/apendices/c_versoes_usadas.md
@@ -11,7 +11,7 @@
 ## Bibliotecas de desenvolvimento
 
 ```toml
---8<-- "codigo_das_aulas/13/pyproject.toml:23:32"
+--8<-- "codigo_das_aulas/13/pyproject.toml:23:34"
 ```
 
 ### Lock de todo o ambiente

--- a/aulas/codigos/01/pyproject.toml
+++ b/aulas/codigos/01/pyproject.toml
@@ -8,15 +8,16 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "fastapi[standard] (>=0.116.2,<0.117.0)"
+    "fastapi[standard] (>=0.129.0,<0.130.0)"
 ]
 
 [dependency-groups]
 dev = [
-    "pytest (>=8.4.2,<9.0.0)",
+    "pytest (>=9.0.2,<10.0.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "taskipy (>=1.14.1,<2.0.0)",
-    "ruff (>=0.13.0,<0.14.0)"
+    "ruff (>=0.15.1,<0.16.0)",
+    "typos (>=1.43.5,<2.0.0)",
 ]
 
 [tool.ruff]
@@ -36,6 +37,7 @@ pythonpath = "."
 addopts = '-p no:warnings'
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/changelogs/+fd1c7144.adicionado.md
+++ b/changelogs/+fd1c7144.adicionado.md
@@ -1,0 +1,1 @@
+Analizador estático para erros de grafia `typos`. Alterações nas aulas 01 e 10.

--- a/codigo_das_aulas/01/poetry.lock
+++ b/codigo_das_aulas/01/poetry.lock
@@ -1667,6 +1667,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1971,4 +1991,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "223251b55075df35d440a729fd3e6f5d70a2359933d63957c3e68f7e1d8a62f3"
+content-hash = "6a037d0c41a1c5e0149441f471b174b91b4fe3ca18b8c479b58aeef39d18a6ae"

--- a/codigo_das_aulas/01/pyproject.toml
+++ b/codigo_das_aulas/01/pyproject.toml
@@ -16,7 +16,8 @@ dev = [
     "pytest (>=9.0.2,<10.0.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "taskipy (>=1.14.1,<2.0.0)",
-    "ruff (>=0.15.1,<0.16.0)"
+    "ruff (>=0.15.1,<0.16.0)",
+    "typos (>=1.43.5,<2.0.0)",
 ]
 
 [tool.ruff]
@@ -36,6 +37,7 @@ pythonpath = "."
 addopts = '-p no:warnings'
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/02/poetry.lock
+++ b/codigo_das_aulas/02/poetry.lock
@@ -1667,6 +1667,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1971,4 +1991,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "223251b55075df35d440a729fd3e6f5d70a2359933d63957c3e68f7e1d8a62f3"
+content-hash = "6a037d0c41a1c5e0149441f471b174b91b4fe3ca18b8c479b58aeef39d18a6ae"

--- a/codigo_das_aulas/02/pyproject.toml
+++ b/codigo_das_aulas/02/pyproject.toml
@@ -16,7 +16,8 @@ dev = [
     "pytest (>=9.0.2,<10.0.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "taskipy (>=1.14.1,<2.0.0)",
-    "ruff (>=0.15.1,<0.16.0)"
+    "ruff (>=0.15.1,<0.16.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -36,6 +37,7 @@ pythonpath = "."
 addopts = '-p no:warnings'
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/03/poetry.lock
+++ b/codigo_das_aulas/03/poetry.lock
@@ -1667,6 +1667,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1971,4 +1991,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "223251b55075df35d440a729fd3e6f5d70a2359933d63957c3e68f7e1d8a62f3"
+content-hash = "6a037d0c41a1c5e0149441f471b174b91b4fe3ca18b8c479b58aeef39d18a6ae"

--- a/codigo_das_aulas/03/pyproject.toml
+++ b/codigo_das_aulas/03/pyproject.toml
@@ -16,7 +16,8 @@ dev = [
     "pytest (>=9.0.2,<10.0.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "taskipy (>=1.14.1,<2.0.0)",
-    "ruff (>=0.15.1,<0.16.0)"
+    "ruff (>=0.15.1,<0.16.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -36,6 +37,7 @@ pythonpath = "."
 addopts = '-p no:warnings'
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/04/poetry.lock
+++ b/codigo_das_aulas/04/poetry.lock
@@ -1873,6 +1873,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2177,4 +2197,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "4286260327e8c656a15a5c0ec2d000d70099fddab322deaad199770ca7db680b"
+content-hash = "6507eee14aecfa58f0379dffb1083a221e3f5d8b4a86d7a39ae4a290f510f958"

--- a/codigo_das_aulas/04/pyproject.toml
+++ b/codigo_das_aulas/04/pyproject.toml
@@ -19,7 +19,8 @@ dev = [
     "pytest (>=9.0.2,<10.0.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "taskipy (>=1.14.1,<2.0.0)",
-    "ruff (>=0.15.1,<0.16.0)"
+    "ruff (>=0.15.1,<0.16.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -39,6 +40,7 @@ pythonpath = "."
 addopts = '-p no:warnings'
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/05/poetry.lock
+++ b/codigo_das_aulas/05/poetry.lock
@@ -1873,6 +1873,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2177,4 +2197,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "4286260327e8c656a15a5c0ec2d000d70099fddab322deaad199770ca7db680b"
+content-hash = "6507eee14aecfa58f0379dffb1083a221e3f5d8b4a86d7a39ae4a290f510f958"

--- a/codigo_das_aulas/05/pyproject.toml
+++ b/codigo_das_aulas/05/pyproject.toml
@@ -19,7 +19,8 @@ dev = [
     "pytest (>=9.0.2,<10.0.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "taskipy (>=1.14.1,<2.0.0)",
-    "ruff (>=0.15.1,<0.16.0)"
+    "ruff (>=0.15.1,<0.16.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -39,6 +40,7 @@ pythonpath = "."
 addopts = '-p no:warnings'
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/06/poetry.lock
+++ b/codigo_das_aulas/06/poetry.lock
@@ -2077,6 +2077,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2393,4 +2413,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "3dbca15b002db2d8c689534078bef0d92cf8f79dd50bc29a22df8e0f737fb095"
+content-hash = "9aa374095ed351e47fca03c0c08255e2ff6293764df6c342058f281e765ba93f"

--- a/codigo_das_aulas/06/pyproject.toml
+++ b/codigo_das_aulas/06/pyproject.toml
@@ -22,7 +22,8 @@ dev = [
     "pytest (>=9.0.2,<10.0.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "taskipy (>=1.14.1,<2.0.0)",
-    "ruff (>=0.15.1,<0.16.0)"
+    "ruff (>=0.15.1,<0.16.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -42,6 +43,7 @@ pythonpath = "."
 addopts = '-p no:warnings'
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/07/poetry.lock
+++ b/codigo_das_aulas/07/poetry.lock
@@ -2077,6 +2077,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2393,4 +2413,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "3dbca15b002db2d8c689534078bef0d92cf8f79dd50bc29a22df8e0f737fb095"
+content-hash = "9aa374095ed351e47fca03c0c08255e2ff6293764df6c342058f281e765ba93f"

--- a/codigo_das_aulas/07/pyproject.toml
+++ b/codigo_das_aulas/07/pyproject.toml
@@ -22,7 +22,8 @@ dev = [
     "pytest (>=9.0.2,<10.0.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "taskipy (>=1.14.1,<2.0.0)",
-    "ruff (>=0.15.1,<0.16.0)"
+    "ruff (>=0.15.1,<0.16.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -42,6 +43,7 @@ pythonpath = "."
 addopts = '-p no:warnings'
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/08/poetry.lock
+++ b/codigo_das_aulas/08/poetry.lock
@@ -2193,6 +2193,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2510,4 +2530,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "1e510401b55a61d8b3dae95cc7e4151b5689c8d23a2fc0736ca0ada379cdd47b"
+content-hash = "9abe638cb73747e7a1acbb20bde5fa202b5280e505c2597435cdc56ddca35927"

--- a/codigo_das_aulas/08/pyproject.toml
+++ b/codigo_das_aulas/08/pyproject.toml
@@ -26,7 +26,8 @@ dev = [
     "ruff (>=0.15.1,<0.16.0)",
     "pytest-asyncio (>=1.3.0,<2.0.0)",
     "factory-boy (>=3.3.3,<4.0.0)",
-    "freezegun (>=1.5.5,<2.0.0)"
+    "freezegun (>=1.5.5,<2.0.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -51,6 +52,7 @@ core = "ctrace"
 concurrency = ["thread", "greenlet"]
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/09/poetry.lock
+++ b/codigo_das_aulas/09/poetry.lock
@@ -2193,6 +2193,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2510,4 +2530,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "6a4d9ae444f2120b3f2dfacd9a93e605b89c71d46966d2cbc318bcbe1501ec61"
+content-hash = "31e025b55ee1f784499ff8f962bee9ed7d160b2aa1f79cbe8e9a88c2a152e16e"

--- a/codigo_das_aulas/09/pyproject.toml
+++ b/codigo_das_aulas/09/pyproject.toml
@@ -26,7 +26,8 @@ dev = [
     "ruff (>=0.15.1,<0.16.0)",
     "pytest-asyncio (>=1.3.0,<2.0.0)",
     "factory-boy (>=3.3.3,<4.0.0)",
-    "freezegun (>=1.5.5,<2.0.0)"
+    "freezegun (>=1.5.5,<2.0.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -51,6 +52,7 @@ core = "ctrace"
 concurrency = ["thread", "greenlet"]
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/10/_typos.toml
+++ b/codigo_das_aulas/10/_typos.toml
@@ -1,0 +1,2 @@
+[default]
+extend-ignore-identifiers-re = ["selectin"]

--- a/codigo_das_aulas/10/poetry.lock
+++ b/codigo_das_aulas/10/poetry.lock
@@ -2445,6 +2445,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2849,4 +2869,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "b585d934a3faeb7e175ecf07cf43b6cb9ff9816fb4ab998490da7a7d16cb1bb0"
+content-hash = "ebeebabd3d6b7479ee6cb1ef0cce09931c62d17fa6cd3f60dd43eaffa81ce3ca"

--- a/codigo_das_aulas/10/pyproject.toml
+++ b/codigo_das_aulas/10/pyproject.toml
@@ -27,7 +27,8 @@ dev = [
     "pytest-asyncio (>=1.3.0,<2.0.0)",
     "factory-boy (>=3.3.3,<4.0.0)",
     "freezegun (>=1.5.5,<2.0.0)",
-    "testcontainers (>=4.14.1,<5.0.0)"
+    "testcontainers (>=4.14.1,<5.0.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -52,6 +53,7 @@ core = "ctrace"
 concurrency = ["thread", "greenlet"]
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/11/_typos.toml
+++ b/codigo_das_aulas/11/_typos.toml
@@ -1,0 +1,2 @@
+[default]
+extend-ignore-identifiers-re = ["selectin"]

--- a/codigo_das_aulas/11/poetry.lock
+++ b/codigo_das_aulas/11/poetry.lock
@@ -2536,6 +2536,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2940,4 +2960,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "920ff5fd4d22a4412fd711db133487a73554b575e98948d602c88481a29325e8"
+content-hash = "5ecb67ef0116ea78add4d4f3e309e98814a3851254df517ff32e7b7a300c035a"

--- a/codigo_das_aulas/11/pyproject.toml
+++ b/codigo_das_aulas/11/pyproject.toml
@@ -28,7 +28,8 @@ dev = [
     "pytest-asyncio (>=1.3.0,<2.0.0)",
     "factory-boy (>=3.3.3,<4.0.0)",
     "freezegun (>=1.5.5,<2.0.0)",
-    "testcontainers (>=4.14.1,<5.0.0)"
+    "testcontainers (>=4.14.1,<5.0.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -52,6 +53,7 @@ core = "ctrace"
 concurrency = ["thread", "greenlet"]
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/12/_typos.toml
+++ b/codigo_das_aulas/12/_typos.toml
@@ -1,0 +1,2 @@
+[default]
+extend-ignore-identifiers-re = ["selectin"]

--- a/codigo_das_aulas/12/poetry.lock
+++ b/codigo_das_aulas/12/poetry.lock
@@ -2536,6 +2536,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2940,4 +2960,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "920ff5fd4d22a4412fd711db133487a73554b575e98948d602c88481a29325e8"
+content-hash = "5ecb67ef0116ea78add4d4f3e309e98814a3851254df517ff32e7b7a300c035a"

--- a/codigo_das_aulas/12/pyproject.toml
+++ b/codigo_das_aulas/12/pyproject.toml
@@ -28,7 +28,8 @@ dev = [
     "pytest-asyncio (>=1.3.0,<2.0.0)",
     "factory-boy (>=3.3.3,<4.0.0)",
     "freezegun (>=1.5.5,<2.0.0)",
-    "testcontainers (>=4.14.1,<5.0.0)"
+    "testcontainers (>=4.14.1,<5.0.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -53,6 +54,7 @@ core = "ctrace"
 concurrency = ["thread", "greenlet"]
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'

--- a/codigo_das_aulas/13/_typos.toml
+++ b/codigo_das_aulas/13/_typos.toml
@@ -1,0 +1,2 @@
+[default]
+extend-ignore-identifiers-re = ["selectin"]

--- a/codigo_das_aulas/13/poetry.lock
+++ b/codigo_das_aulas/13/poetry.lock
@@ -2536,6 +2536,26 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "typos"
+version = "1.43.5"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.43.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:733221c09d6914c001d2ac16f630773dc36ff384df9ab128c9e93b019eeedf2f"},
+    {file = "typos-1.43.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1d2f86b458917fdc91b89f47101498adc7338361e1ed0bed6e4325d0e674aca"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d75091c9519224f2f74964b6ca5133abfba9be44ce49f12a981e27c29bcef97"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:839dfa2bc802b02460097b21f7d93d0fa87d5f76adb83049072211a7279f5ebe"},
+    {file = "typos-1.43.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0825a4d77d66726e86fac03c6cf2efc11b0a5c112b2156dcaeb61a24a807166"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ee0a71ac21820868686ad52cb26a3e08197b09ceedf04d1736cb8472061665b"},
+    {file = "typos-1.43.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09615c8f64e656940533aa025a9e8dc5c93e5cf6bfbedb059cdcafde75cb6d72"},
+    {file = "typos-1.43.5-py3-none-win32.whl", hash = "sha256:4c865b1b6149acbdaed9d548282ccfad526e1380de19d189e7ac675cd4869156"},
+    {file = "typos-1.43.5-py3-none-win_amd64.whl", hash = "sha256:10009e9a3702da037803b075efc94fa5328bd93af357fb6a2f284c0dbcc77f30"},
+    {file = "typos-1.43.5.tar.gz", hash = "sha256:aa445c5eaf0e32095c3183dda96e0fa8ffcabbfd796721c75d7a8a68e9cd0d75"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2940,4 +2960,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "920ff5fd4d22a4412fd711db133487a73554b575e98948d602c88481a29325e8"
+content-hash = "5ecb67ef0116ea78add4d4f3e309e98814a3851254df517ff32e7b7a300c035a"

--- a/codigo_das_aulas/13/pyproject.toml
+++ b/codigo_das_aulas/13/pyproject.toml
@@ -28,7 +28,8 @@ dev = [
     "pytest-asyncio (>=1.3.0,<2.0.0)",
     "factory-boy (>=3.3.3,<4.0.0)",
     "freezegun (>=1.5.5,<2.0.0)",
-    "testcontainers (>=4.14.1,<5.0.0)"
+    "testcontainers (>=4.14.1,<5.0.0)",
+    "typos (>=1.43.5,<2.0.0)"
 ]
 
 [tool.ruff]
@@ -53,6 +54,7 @@ core = "ctrace"
 concurrency = ["thread", "greenlet"]
 
 [tool.taskipy.tasks]
+pre_lint = 'typos'
 lint = 'ruff check'
 pre_format = 'ruff check --fix'
 format = 'ruff format'


### PR DESCRIPTION
Algumas pessoas tiveram dificuldades por errar a grafia diversas vezes durante o curso. Acho que essa adição pode ajudar de certa forma a que menos erros de escrita em inglês sejam cometidos durante a criação dos códigos do curso.

PS: O typos já estava rodando no CI há bastante tempo. Essa é a inclusão do typos como uma ferramenta do ambiente de desenvolvimento de quem estiver fazendo o curso.